### PR TITLE
Handles missing signal.SIGUSR1 when registering a handler in worker

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -367,7 +367,10 @@ class Worker(object):
         self.run_succeeded = True
         self.unfulfilled_counts = collections.defaultdict(int)
 
-        signal.signal(signal.SIGUSR1, self.handle_interrupt)
+        try:
+            signal.signal(signal.SIGUSR1, self.handle_interrupt)
+        except AttributeError:
+            pass
 
         self._keep_alive_thread = KeepAliveThread(self._scheduler, self._id, self._config.ping_interval)
         self._keep_alive_thread.daemon = True

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -158,7 +158,10 @@ class WorkerTest(unittest.TestCase):
         self.w.add(d)
 
         self.assertFalse(d.complete())
-        self.w.handle_interrupt(signal.SIGUSR1, None)
+        try:
+            self.w.handle_interrupt(signal.SIGUSR1, None)
+        except AttributeError:
+            raise unittest.SkipTest('signal.SIGUSR1 not found on this system')
         self.w.run()
         self.assertFalse(d.complete())
 
@@ -354,6 +357,11 @@ class WorkerTest(unittest.TestCase):
 
         self.assertTrue(self.w.add(B()))
         self.assertFalse(self.w.run())
+
+    def test_fails_registering_signal(self):
+        with mock.patch('luigi.worker.signal', spec=['signal']):
+            # mock will raise an attribute error getting signal.SIGUSR1
+            Worker()
 
     def test_allow_reschedule_with_many_missing_deps(self):
         class A(Task):


### PR DESCRIPTION
Windows machines don't have a signal.SIGUSR1. In order to avoid the
problems that come with registering a SIGTERM handler instead, we just
disable the SIGUSR1 handler on Windows machines. This resolves #1360.